### PR TITLE
Allow User Defined Callbacks and Custom Header like ImGui #115

### DIFF
--- a/example/color_node_editor.cpp
+++ b/example/color_node_editor.cpp
@@ -123,15 +123,68 @@ ImU32 evaluate(const Graph<Node>& graph, const int root_node)
 class ColorNodeEditor
 {
 public:
-    ColorNodeEditor() : graph_(), nodes_(), root_node_id_(-1) {}
+    ColorNodeEditor() : graph_(), nodes_(), root_node_id_(-1),
+        minimap_location_(ImNodesMiniMapLocation_BottomRight) {}
 
     void show()
     {
         // Update timer context
         current_time_seconds = 0.001f * SDL_GetTicks();
 
+        auto flags = ImGuiWindowFlags_MenuBar;
+
         // The node editor window
-        ImGui::Begin("color node editor");
+        ImGui::Begin("color node editor", NULL, flags);
+
+        if (ImGui::BeginMenuBar())
+        {
+            if (ImGui::BeginMenu("Mini-map"))
+            {
+                const char* names[] = {
+                    "Top Left",
+                    "Top Right",
+                    "Bottom Left",
+                    "Bottom Right",
+                };
+                int locations[] = {
+                    ImNodesMiniMapLocation_TopLeft,
+                    ImNodesMiniMapLocation_TopRight,
+                    ImNodesMiniMapLocation_BottomLeft,
+                    ImNodesMiniMapLocation_BottomRight,
+                };
+
+                for (int i = 0; i < 4; i++)
+                {
+                    bool selected = minimap_location_ == locations[i];
+                    if (ImGui::MenuItem(names[i], NULL, &selected))
+                        minimap_location_ = locations[i];
+                }
+                ImGui::EndMenu();
+            }
+
+            if (ImGui::BeginMenu("Style"))
+            {
+                if (ImGui::MenuItem("Classic"))
+                {
+                    ImGui::StyleColorsClassic();
+                    ImNodes::StyleColorsClassic();
+                }
+                if (ImGui::MenuItem("Dark"))
+                {
+                    ImGui::StyleColorsDark();
+                    ImNodes::StyleColorsDark();
+                }
+                if (ImGui::MenuItem("Light"))
+                {
+                    ImGui::StyleColorsLight();
+                    ImNodes::StyleColorsLight();
+                }
+                ImGui::EndMenu();
+            }
+
+            ImGui::EndMenuBar();
+        }
+
         ImGui::TextUnformatted("Edit the color of the output color window using nodes.");
         ImGui::Columns(2);
         ImGui::TextUnformatted("A -- add node");
@@ -489,6 +542,7 @@ public:
             ImNodes::Link(edge.id, edge.from, edge.to);
         }
 
+        ImNodes::MiniMap(0.2f, minimap_location_);
         ImNodes::EndNodeEditor();
 
         // Handle new links
@@ -635,9 +689,10 @@ private:
         };
     };
 
-    Graph<Node>         graph_;
-    std::vector<UiNode> nodes_;
-    int                 root_node_id_;
+    Graph<Node>            graph_;
+    std::vector<UiNode>    nodes_;
+    int                    root_node_id_;
+    ImNodesMiniMapLocation minimap_location_;
 };
 
 static ColorNodeEditor color_editor;

--- a/imnodes.cpp
+++ b/imnodes.cpp
@@ -2590,7 +2590,6 @@ void PushStyleVar(const ImNodesStyleVar item, const float value)
     const ImNodesStyleVarInfo* var_info = GetStyleVarInfo(item);
     if (var_info->Type == ImGuiDataType_Float && var_info->Count == 1)
     {
-        ImGuiContext& g = *GImGui;
         float& style_var = *(float*)var_info->GetVarPtr(&GImNodes->Style);
         GImNodes->StyleModifierStack.push_back(ImNodesStyleVarElement(item, style_var));
         style_var = value;
@@ -2604,7 +2603,6 @@ void PushStyleVar(const ImNodesStyleVar item, const ImVec2& value)
     const ImNodesStyleVarInfo* var_info = GetStyleVarInfo(item);
     if (var_info->Type == ImGuiDataType_Float && var_info->Count == 2)
     {
-        ImGuiContext& g = *GImGui;
         ImVec2& style_var = *(ImVec2*)var_info->GetVarPtr(&GImNodes->Style);
         GImNodes->StyleModifierStack.push_back(ImNodesStyleVarElement(item, style_var));
         style_var = value;

--- a/imnodes.cpp
+++ b/imnodes.cpp
@@ -1846,7 +1846,7 @@ static void MiniMapUpdate()
         mini_map_is_hovered &&
         ImGui::IsMouseDown(ImGuiMouseButton_Left) &&
         editor.ClickInteraction.Type == ImNodesClickInteractionType_None &&
-        !editor.Nodes.Pool.empty();
+        !GImNodes->NodeIdxSubmissionOrder.empty();
     if (center_on_click)
     {
         ImVec2 target = MiniMapSpaceToGridSpace(editor, ImGui::GetMousePos());

--- a/imnodes.cpp
+++ b/imnodes.cpp
@@ -1805,9 +1805,10 @@ static void MiniMapUpdate()
     ImGui::InvisibleButton("minimap", editor.MiniMapRectScreenSpace.GetSize());
 
     bool center_on_click =
+        ImGui::IsMouseDown(ImGuiMouseButton_Left) &&
         editor.ClickInteraction.Type == ImNodesClickInteractionType_None &&
         ImGui::IsItemActive() &&
-        ImGui::IsMouseDown(ImGuiMouseButton_Left);
+        !editor.Nodes.Pool.empty();
     if (center_on_click)
     {
         editor.ClickInteraction.Type = ImNodesClickInteractionType_CenterOnRequest;

--- a/imnodes.cpp
+++ b/imnodes.cpp
@@ -285,23 +285,22 @@ inline ImVec2 EditorSpaceToScreenSpace(const ImVec2& v)
 
 inline ImVec2 MiniMapSpaceToGridSpace(const ImNodesEditorContext& editor, const ImVec2& v)
 {
-    return (v - editor.MiniMapContentScreenSpace.Min) / editor.MiniMapScaling
-        + editor.GridContentBounds.Min;
+    return (v - editor.MiniMapContentScreenSpace.Min) / editor.MiniMapScaling +
+           editor.GridContentBounds.Min;
 };
 
 inline ImVec2 ScreenSpaceToMiniMapSpace(const ImNodesEditorContext& editor, const ImVec2& v)
 {
-    return (ScreenSpaceToGridSpace(editor, v) - editor.GridContentBounds.Min)
-        * editor.MiniMapScaling + editor.MiniMapContentScreenSpace.Min;
+    return (ScreenSpaceToGridSpace(editor, v) - editor.GridContentBounds.Min) *
+               editor.MiniMapScaling +
+           editor.MiniMapContentScreenSpace.Min;
 };
 
 inline ImRect ScreenSpaceToMiniMapSpace(const ImNodesEditorContext& editor, const ImRect& r)
 {
     return ImRect(
-        ScreenSpaceToMiniMapSpace(editor, r.Min),
-        ScreenSpaceToMiniMapSpace(editor, r.Max));
+        ScreenSpaceToMiniMapSpace(editor, r.Min), ScreenSpaceToMiniMapSpace(editor, r.Max));
 };
-
 
 // [SECTION] draw list helper
 
@@ -1628,7 +1627,8 @@ void Shutdown(ImNodesContext* ctx) { EditorContextFree(ctx->DefaultEditorCtx); }
 
 // [SECTION] minimap
 
-static inline bool IsMiniMapActive() {
+static inline bool IsMiniMapActive()
+{
     ImNodesEditorContext& editor = EditorContextGet();
     return editor.MiniMapEnabled && editor.MiniMapSizeFraction > 0.0f;
 }
@@ -1644,23 +1644,25 @@ static inline bool IsMiniMapHovered()
 static inline void CalcMiniMapLayout()
 {
     ImNodesEditorContext& editor = EditorContextGet();
-    const ImVec2 offset = GImNodes->Style.MiniMapOffset;
-    const ImVec2 border = GImNodes->Style.MiniMapPadding;
-    const ImRect editor_rect = GImNodes->CanvasRectScreenSpace;
+    const ImVec2          offset = GImNodes->Style.MiniMapOffset;
+    const ImVec2          border = GImNodes->Style.MiniMapPadding;
+    const ImRect          editor_rect = GImNodes->CanvasRectScreenSpace;
 
     // Compute the size of the mini-map area
     ImVec2 mini_map_size;
-    float mini_map_scaling;
+    float  mini_map_scaling;
     {
-        const ImVec2 max_size = ImFloor(editor_rect.GetSize() * editor.MiniMapSizeFraction - border * 2.0f);
+        const ImVec2 max_size =
+            ImFloor(editor_rect.GetSize() * editor.MiniMapSizeFraction - border * 2.0f);
         const float  max_size_aspect_ratio = max_size.x / max_size.y;
         const ImVec2 grid_content_size = editor.GridContentBounds.IsInverted()
-            ? max_size
-            : ImFloor(editor.GridContentBounds.GetSize());
+                                             ? max_size
+                                             : ImFloor(editor.GridContentBounds.GetSize());
         const float  grid_content_aspect_ratio = grid_content_size.x / grid_content_size.y;
-        mini_map_size = ImFloor(grid_content_aspect_ratio > max_size_aspect_ratio
-            ? ImVec2(max_size.x, max_size.x / grid_content_aspect_ratio)
-            : ImVec2(max_size.y * grid_content_aspect_ratio, max_size.y));
+        mini_map_size = ImFloor(
+            grid_content_aspect_ratio > max_size_aspect_ratio
+                ? ImVec2(max_size.x, max_size.x / grid_content_aspect_ratio)
+                : ImVec2(max_size.y * grid_content_aspect_ratio, max_size.y));
         mini_map_scaling = mini_map_size.x / grid_content_size.x;
     }
 
@@ -1671,26 +1673,37 @@ static inline void CalcMiniMapLayout()
 
         switch (editor.MiniMapLocation)
         {
-        case ImNodesMiniMapLocation_BottomRight: align.x = 1.0f; align.y = 1.0f; break;
-        case ImNodesMiniMapLocation_BottomLeft:  align.x = 0.0f; align.y = 1.0f; break;
-        case ImNodesMiniMapLocation_TopRight:    align.x = 1.0f; align.y = 0.0f; break;
-        case ImNodesMiniMapLocation_TopLeft:     // [[fallthrough]]
-        default:                                 align.x = 0.0f; align.y = 0.0f; break;
+        case ImNodesMiniMapLocation_BottomRight:
+            align.x = 1.0f;
+            align.y = 1.0f;
+            break;
+        case ImNodesMiniMapLocation_BottomLeft:
+            align.x = 0.0f;
+            align.y = 1.0f;
+            break;
+        case ImNodesMiniMapLocation_TopRight:
+            align.x = 1.0f;
+            align.y = 0.0f;
+            break;
+        case ImNodesMiniMapLocation_TopLeft: // [[fallthrough]]
+        default:
+            align.x = 0.0f;
+            align.y = 0.0f;
+            break;
         }
 
-        const ImVec2 top_left_pos     = editor_rect.Min + offset + border;
+        const ImVec2 top_left_pos = editor_rect.Min + offset + border;
         const ImVec2 bottom_right_pos = editor_rect.Max - offset - border - mini_map_size;
         mini_map_pos = ImFloor(ImLerp(top_left_pos, bottom_right_pos, align));
     }
 
-    editor.MiniMapRectScreenSpace = ImRect(mini_map_pos - border, mini_map_pos + mini_map_size + border);
+    editor.MiniMapRectScreenSpace =
+        ImRect(mini_map_pos - border, mini_map_pos + mini_map_size + border);
     editor.MiniMapContentScreenSpace = ImRect(mini_map_pos, mini_map_pos + mini_map_size);
     editor.MiniMapScaling = mini_map_scaling;
 }
 
-static void MiniMapDrawNode(
-    ImNodesEditorContext& editor,
-    const int             node_idx)
+static void MiniMapDrawNode(ImNodesEditorContext& editor, const int node_idx)
 {
     const ImNodeData& node = editor.Nodes.Pool[node_idx];
 
@@ -1710,8 +1723,7 @@ static void MiniMapDrawNode(
         // Run user callback when hovering a mini-map node
         if (editor.MiniMapNodeHoveringCallback)
         {
-            editor.MiniMapNodeHoveringCallback(
-                node.Id, editor.MiniMapNodeHoveringCallbackUserData);
+            editor.MiniMapNodeHoveringCallback(node.Id, editor.MiniMapNodeHoveringCallbackUserData);
         }
     }
     else if (editor.SelectedNodeIndices.contains(node_idx))
@@ -1732,9 +1744,7 @@ static void MiniMapDrawNode(
         node_rect.Min, node_rect.Max, mini_map_node_outline, mini_map_node_rounding);
 }
 
-static void MiniMapDrawLink(
-    ImNodesEditorContext& editor,
-    const int             link_idx)
+static void MiniMapDrawLink(ImNodesEditorContext& editor, const int link_idx)
 {
     const ImLinkData& link = editor.Links.Pool[link_idx];
     const ImPinData&  start_pin = editor.Pins.Pool[link.StartPinIdx];
@@ -1827,8 +1837,8 @@ static void MiniMapUpdate()
 
     // Draw editor canvas rect inside mini-map
     {
-        const ImU32 canvas_color = GImNodes->Style.Colors[ImNodesCol_MiniMapCanvas];
-        const ImU32 outline_color = GImNodes->Style.Colors[ImNodesCol_MiniMapCanvasOutline];
+        const ImU32  canvas_color = GImNodes->Style.Colors[ImNodesCol_MiniMapCanvas];
+        const ImU32  outline_color = GImNodes->Style.Colors[ImNodesCol_MiniMapCanvasOutline];
         const ImRect rect = ScreenSpaceToMiniMapSpace(editor, GImNodes->CanvasRectScreenSpace);
 
         GImNodes->CanvasDrawList->AddRectFilled(rect.Min, rect.Max, canvas_color);
@@ -1842,11 +1852,9 @@ static void MiniMapUpdate()
 
     ImGui::EndChild();
 
-    bool center_on_click =
-        mini_map_is_hovered &&
-        ImGui::IsMouseDown(ImGuiMouseButton_Left) &&
-        editor.ClickInteraction.Type == ImNodesClickInteractionType_None &&
-        !GImNodes->NodeIdxSubmissionOrder.empty();
+    bool center_on_click = mini_map_is_hovered && ImGui::IsMouseDown(ImGuiMouseButton_Left) &&
+                           editor.ClickInteraction.Type == ImNodesClickInteractionType_None &&
+                           !GImNodes->NodeIdxSubmissionOrder.empty();
     if (center_on_click)
     {
         ImVec2 target = MiniMapSpaceToGridSpace(editor, ImGui::GetMousePos());
@@ -1905,13 +1913,12 @@ ImNodesIO::ImNodesIO()
 }
 
 ImNodesStyle::ImNodesStyle()
-    : GridSpacing(32.f), NodeCornerRounding(4.f), NodePadding(8.f, 8.f),
-      NodeBorderThickness(1.f), LinkThickness(3.f),
-      LinkLineSegmentsPerLength(0.1f), LinkHoverDistance(10.f), PinCircleRadius(4.f),
-      PinQuadSideLength(7.f), PinTriangleSideLength(9.5), PinLineThickness(1.f),
-      PinHoverRadius(10.f), PinOffset(0.f),
-      MiniMapPadding(8.0f, 8.0f), MiniMapOffset(4.0f, 4.0f),
-      Flags(ImNodesStyleFlags_NodeOutline | ImNodesStyleFlags_GridLines), Colors()
+    : GridSpacing(32.f), NodeCornerRounding(4.f), NodePadding(8.f, 8.f), NodeBorderThickness(1.f),
+      LinkThickness(3.f), LinkLineSegmentsPerLength(0.1f), LinkHoverDistance(10.f),
+      PinCircleRadius(4.f), PinQuadSideLength(7.f), PinTriangleSideLength(9.5),
+      PinLineThickness(1.f), PinHoverRadius(10.f), PinOffset(0.f), MiniMapPadding(8.0f, 8.0f),
+      MiniMapOffset(4.0f, 4.0f), Flags(ImNodesStyleFlags_NodeOutline | ImNodesStyleFlags_GridLines),
+      Colors()
 {
 }
 
@@ -2535,44 +2542,43 @@ void PopColorStyle()
 
 struct ImNodesStyleVarInfo
 {
-    ImGuiDataType   Type;
-    ImU32           Count;
-    ImU32           Offset;
-    void*           GetVarPtr(ImNodesStyle* style) const { return (void*)((unsigned char*)style + Offset); }
+    ImGuiDataType Type;
+    ImU32         Count;
+    ImU32         Offset;
+    void* GetVarPtr(ImNodesStyle* style) const { return (void*)((unsigned char*)style + Offset); }
 };
 
-static const ImNodesStyleVarInfo GStyleVarInfo[] =
-{
+static const ImNodesStyleVarInfo GStyleVarInfo[] = {
     // ImNodesStyleVar_GridSpacing
-    { ImGuiDataType_Float, 1, (ImU32)IM_OFFSETOF(ImNodesStyle, GridSpacing) },
+    {ImGuiDataType_Float, 1, (ImU32)IM_OFFSETOF(ImNodesStyle, GridSpacing)},
     // ImNodesStyleVar_NodeCornerRounding
-    { ImGuiDataType_Float, 1, (ImU32)IM_OFFSETOF(ImNodesStyle, NodeCornerRounding) },
+    {ImGuiDataType_Float, 1, (ImU32)IM_OFFSETOF(ImNodesStyle, NodeCornerRounding)},
     // ImNodesStyleVar_NodePadding
-    { ImGuiDataType_Float, 2, (ImU32)IM_OFFSETOF(ImNodesStyle, NodePadding) },
+    {ImGuiDataType_Float, 2, (ImU32)IM_OFFSETOF(ImNodesStyle, NodePadding)},
     // ImNodesStyleVar_NodeBorderThickness
-    { ImGuiDataType_Float, 1, (ImU32)IM_OFFSETOF(ImNodesStyle, NodeBorderThickness) },
+    {ImGuiDataType_Float, 1, (ImU32)IM_OFFSETOF(ImNodesStyle, NodeBorderThickness)},
     // ImNodesStyleVar_LinkThickness
-    { ImGuiDataType_Float, 1, (ImU32)IM_OFFSETOF(ImNodesStyle, LinkThickness) },
+    {ImGuiDataType_Float, 1, (ImU32)IM_OFFSETOF(ImNodesStyle, LinkThickness)},
     // ImNodesStyleVar_LinkLineSegmentsPerLength
-    { ImGuiDataType_Float, 1, (ImU32)IM_OFFSETOF(ImNodesStyle, LinkLineSegmentsPerLength) },
+    {ImGuiDataType_Float, 1, (ImU32)IM_OFFSETOF(ImNodesStyle, LinkLineSegmentsPerLength)},
     // ImNodesStyleVar_LinkHoverDistance
-    { ImGuiDataType_Float, 1, (ImU32)IM_OFFSETOF(ImNodesStyle, LinkHoverDistance) },
+    {ImGuiDataType_Float, 1, (ImU32)IM_OFFSETOF(ImNodesStyle, LinkHoverDistance)},
     // ImNodesStyleVar_PinCircleRadius
-    { ImGuiDataType_Float, 1, (ImU32)IM_OFFSETOF(ImNodesStyle, PinCircleRadius) },
+    {ImGuiDataType_Float, 1, (ImU32)IM_OFFSETOF(ImNodesStyle, PinCircleRadius)},
     // ImNodesStyleVar_PinQuadSideLength
-    { ImGuiDataType_Float, 1, (ImU32)IM_OFFSETOF(ImNodesStyle, PinQuadSideLength) },
+    {ImGuiDataType_Float, 1, (ImU32)IM_OFFSETOF(ImNodesStyle, PinQuadSideLength)},
     // ImNodesStyleVar_PinTriangleSideLength
-    { ImGuiDataType_Float, 1, (ImU32)IM_OFFSETOF(ImNodesStyle, PinTriangleSideLength) },
+    {ImGuiDataType_Float, 1, (ImU32)IM_OFFSETOF(ImNodesStyle, PinTriangleSideLength)},
     // ImNodesStyleVar_PinLineThickness
-    { ImGuiDataType_Float, 1, (ImU32)IM_OFFSETOF(ImNodesStyle, PinLineThickness) },
+    {ImGuiDataType_Float, 1, (ImU32)IM_OFFSETOF(ImNodesStyle, PinLineThickness)},
     // ImNodesStyleVar_PinHoverRadius
-    { ImGuiDataType_Float, 1, (ImU32)IM_OFFSETOF(ImNodesStyle, PinHoverRadius) },
+    {ImGuiDataType_Float, 1, (ImU32)IM_OFFSETOF(ImNodesStyle, PinHoverRadius)},
     // ImNodesStyleVar_PinOffset
-    { ImGuiDataType_Float, 1, (ImU32)IM_OFFSETOF(ImNodesStyle, PinOffset) },
+    {ImGuiDataType_Float, 1, (ImU32)IM_OFFSETOF(ImNodesStyle, PinOffset)},
     // ImNodesStyleVar_MiniMapPadding
-    { ImGuiDataType_Float, 2, (ImU32)IM_OFFSETOF(ImNodesStyle, MiniMapPadding) },
+    {ImGuiDataType_Float, 2, (ImU32)IM_OFFSETOF(ImNodesStyle, MiniMapPadding)},
     // ImNodesStyleVar_MiniMapOffset
-    { ImGuiDataType_Float, 2, (ImU32)IM_OFFSETOF(ImNodesStyle, MiniMapOffset) },
+    {ImGuiDataType_Float, 2, (ImU32)IM_OFFSETOF(ImNodesStyle, MiniMapOffset)},
 };
 
 static const ImNodesStyleVarInfo* GetStyleVarInfo(ImNodesStyleVar idx)
@@ -2610,12 +2616,13 @@ void PushStyleVar(const ImNodesStyleVar item, const ImVec2& value)
 
 void PopStyleVar(int count)
 {
-    while (count > 0) {
+    while (count > 0)
+    {
         assert(GImNodes->StyleModifierStack.size() > 0);
         const ImNodesStyleVarElement style_backup = GImNodes->StyleModifierStack.back();
         GImNodes->StyleModifierStack.pop_back();
         const ImNodesStyleVarInfo* var_info = GetStyleVarInfo(style_backup.Item);
-        void* style_var = var_info->GetVarPtr(&GImNodes->Style);
+        void*                      style_var = var_info->GetVarPtr(&GImNodes->Style);
         if (var_info->Type == ImGuiDataType_Float && var_info->Count == 1)
         {
             ((float*)style_var)[0] = style_backup.FloatValue[0];

--- a/imnodes.cpp
+++ b/imnodes.cpp
@@ -1905,8 +1905,8 @@ ImNodesIO::ImNodesIO()
 }
 
 ImNodesStyle::ImNodesStyle()
-    : GridSpacing(32.f), NodeCornerRounding(4.f), NodePaddingHorizontal(8.f),
-      NodePaddingVertical(8.f), NodeBorderThickness(1.f), LinkThickness(3.f),
+    : GridSpacing(32.f), NodeCornerRounding(4.f), NodePadding(8.f, 8.f),
+      NodeBorderThickness(1.f), LinkThickness(3.f),
       LinkLineSegmentsPerLength(0.1f), LinkHoverDistance(10.f), PinCircleRadius(4.f),
       PinQuadSideLength(7.f), PinTriangleSideLength(9.5), PinLineThickness(1.f),
       PinHoverRadius(10.f), PinOffset(0.f),
@@ -2368,8 +2368,7 @@ void BeginNode(const int node_id)
     node.ColorStyle.TitlebarHovered = GImNodes->Style.Colors[ImNodesCol_TitleBarHovered];
     node.ColorStyle.TitlebarSelected = GImNodes->Style.Colors[ImNodesCol_TitleBarSelected];
     node.LayoutStyle.CornerRounding = GImNodes->Style.NodeCornerRounding;
-    node.LayoutStyle.Padding =
-        ImVec2(GImNodes->Style.NodePaddingHorizontal, GImNodes->Style.NodePaddingVertical);
+    node.LayoutStyle.Padding = GImNodes->Style.NodePadding;
     node.LayoutStyle.BorderThickness = GImNodes->Style.NodeBorderThickness;
 
     // ImGui::SetCursorPos sets the cursor position, local to the current widget
@@ -2548,10 +2547,8 @@ static const ImNodesStyleVarInfo GStyleVarInfo[] =
     { ImGuiDataType_Float, 1, (ImU32)IM_OFFSETOF(ImNodesStyle, GridSpacing) },
     // ImNodesStyleVar_NodeCornerRounding
     { ImGuiDataType_Float, 1, (ImU32)IM_OFFSETOF(ImNodesStyle, NodeCornerRounding) },
-    // ImNodesStyleVar_NodePaddingHorizontal
-    { ImGuiDataType_Float, 1, (ImU32)IM_OFFSETOF(ImNodesStyle, NodePaddingHorizontal) },
-    // ImNodesStyleVar_NodePaddingVertical
-    { ImGuiDataType_Float, 1, (ImU32)IM_OFFSETOF(ImNodesStyle, NodePaddingVertical) },
+    // ImNodesStyleVar_NodePadding
+    { ImGuiDataType_Float, 2, (ImU32)IM_OFFSETOF(ImNodesStyle, NodePadding) },
     // ImNodesStyleVar_NodeBorderThickness
     { ImGuiDataType_Float, 1, (ImU32)IM_OFFSETOF(ImNodesStyle, NodeBorderThickness) },
     // ImNodesStyleVar_LinkThickness

--- a/imnodes.cpp
+++ b/imnodes.cpp
@@ -2564,6 +2564,10 @@ static const ImNodesStyleVarInfo GStyleVarInfo[] =
     { ImGuiDataType_Float, 1, (ImU32)IM_OFFSETOF(ImNodesStyle, PinHoverRadius) },
     // ImNodesStyleVar_PinOffset
     { ImGuiDataType_Float, 1, (ImU32)IM_OFFSETOF(ImNodesStyle, PinOffset) },
+    // ImNodesStyleVar_MiniMapPadding
+    { ImGuiDataType_Float, 2, (ImU32)IM_OFFSETOF(ImNodesStyle, MiniMapPadding) },
+    // ImNodesStyleVar_MiniMapOffset
+    { ImGuiDataType_Float, 2, (ImU32)IM_OFFSETOF(ImNodesStyle, MiniMapOffset) },
 };
 
 static const ImNodesStyleVarInfo* GetStyleVarInfo(ImNodesStyleVar idx)

--- a/imnodes.cpp
+++ b/imnodes.cpp
@@ -258,6 +258,11 @@ inline ImVec2 ScreenSpaceToGridSpace(const ImNodesEditorContext& editor, const I
     return v - GImNodes->CanvasOriginScreenSpace - editor.Panning;
 }
 
+inline ImRect ScreenSpaceToGridSpace(const ImNodesEditorContext& editor, const ImRect& r)
+{
+    return ImRect(ScreenSpaceToGridSpace(editor, r.Min), ScreenSpaceToGridSpace(editor, r.Max));
+}
+
 inline ImVec2 GridSpaceToScreenSpace(const ImNodesEditorContext& editor, const ImVec2& v)
 {
     return v + GImNodes->CanvasOriginScreenSpace + editor.Panning;
@@ -2176,6 +2181,12 @@ void EndNodeEditor()
     GImNodes->CurrentScope = ImNodesScope_None;
 
     ImNodesEditorContext& editor = EditorContextGet();
+
+    bool no_grid_content = editor.GridContentBounds.IsInverted();
+    if (no_grid_content)
+    {
+        editor.GridContentBounds = ScreenSpaceToGridSpace(editor, GImNodes->CanvasRectScreenSpace);
+    }
 
     // Detect ImGui interaction first, because it blocks interaction with the rest of the UI
 

--- a/imnodes.cpp
+++ b/imnodes.cpp
@@ -1655,10 +1655,12 @@ static inline void CalcMiniMapLayout()
     ImVec2 mini_map_size;
     float mini_map_scaling;
     {
-        const ImVec2 grid_content_size = ImFloor(editor.GridContentBounds.GetSize());
-        const float  grid_content_aspect_ratio = grid_content_size.x / grid_content_size.y;
         const ImVec2 max_size = ImFloor(editor_rect.GetSize() * editor.MiniMapSizeFraction - border * 2.0f);
         const float  max_size_aspect_ratio = max_size.x / max_size.y;
+        const ImVec2 grid_content_size = editor.GridContentBounds.IsInverted()
+            ? max_size
+            : ImFloor(editor.GridContentBounds.GetSize());
+        const float  grid_content_aspect_ratio = grid_content_size.x / grid_content_size.y;
         mini_map_size = ImFloor(grid_content_aspect_ratio > max_size_aspect_ratio
             ? ImVec2(max_size.x, max_size.x / grid_content_aspect_ratio)
             : ImVec2(max_size.y * grid_content_aspect_ratio, max_size.y));

--- a/imnodes.cpp
+++ b/imnodes.cpp
@@ -1908,7 +1908,7 @@ ImNodesStyle::ImNodesStyle()
       LinkLineSegmentsPerLength(0.1f), LinkHoverDistance(10.f), PinCircleRadius(4.f),
       PinQuadSideLength(7.f), PinTriangleSideLength(9.5), PinLineThickness(1.f),
       PinHoverRadius(10.f), PinOffset(0.f),
-      MiniMapPadding(4.0f, 4.0f), MiniMapOffset(4.0f, 4.0f),
+      MiniMapPadding(8.0f, 8.0f), MiniMapOffset(4.0f, 4.0f),
       Flags(ImNodesStyleFlags_NodeOutline | ImNodesStyleFlags_GridLines), Colors()
 {
 }

--- a/imnodes.h
+++ b/imnodes.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include <stddef.h>
+#include <imgui.h>
 
 #ifndef IMNODES_NAMESPACE
 #define IMNODES_NAMESPACE ImNodes
@@ -41,6 +42,8 @@ enum ImNodesCol_
     ImNodesCol_MiniMapNodeOutline,
     ImNodesCol_MiniMapLink,
     ImNodesCol_MiniMapLinkSelected,
+    ImNodesCol_MiniMapCanvas,
+    ImNodesCol_MiniMapCanvasOutline,
     ImNodesCol_COUNT
 };
 
@@ -167,6 +170,11 @@ struct ImNodesStyle
     float PinHoverRadius;
     // Offsets the pins' positions from the edge of the node to the outside of the node.
     float PinOffset;
+
+    // Mini-map padding size between mini-map edge and mini-map content.
+    ImVec2 MiniMapPadding;
+    // Mini-map offset from the screen side.
+    ImVec2 MiniMapOffset;
 
     // By default, ImNodesStyleFlags_NodeOutline and ImNodesStyleFlags_Gridlines are enabled.
     ImNodesStyleFlags Flags;

--- a/imnodes.h
+++ b/imnodes.h
@@ -63,6 +63,8 @@ enum ImNodesStyleVar_
     ImNodesStyleVar_PinLineThickness,
     ImNodesStyleVar_PinHoverRadius,
     ImNodesStyleVar_PinOffset,
+    ImNodesStyleVar_MiniMapPadding,
+    ImNodesStyleVar_MiniMapOffset,
     ImNodesStyleVar_COUNT
 };
 

--- a/imnodes.h
+++ b/imnodes.h
@@ -144,9 +144,9 @@ struct ImNodesStyle
 {
     float GridSpacing;
 
-    float NodeCornerRounding;
+    float  NodeCornerRounding;
     ImVec2 NodePadding;
-    float NodeBorderThickness;
+    float  NodeBorderThickness;
 
     float LinkThickness;
     float LinkLineSegmentsPerLength;

--- a/imnodes.h
+++ b/imnodes.h
@@ -62,7 +62,8 @@ enum ImNodesStyleVar_
     ImNodesStyleVar_PinTriangleSideLength,
     ImNodesStyleVar_PinLineThickness,
     ImNodesStyleVar_PinHoverRadius,
-    ImNodesStyleVar_PinOffset
+    ImNodesStyleVar_PinOffset,
+    ImNodesStyleVar_COUNT
 };
 
 enum ImNodesStyleFlags_
@@ -252,7 +253,8 @@ void MiniMap(
 void PushColorStyle(ImNodesCol item, unsigned int color);
 void PopColorStyle();
 void PushStyleVar(ImNodesStyleVar style_item, float value);
-void PopStyleVar();
+void PushStyleVar(ImNodesStyleVar style_item, const ImVec2& value);
+void PopStyleVar(int count = 1);
 
 // id can be any positive or negative integer, but INT_MIN is currently reserved for internal use.
 void BeginNode(int id);

--- a/imnodes.h
+++ b/imnodes.h
@@ -51,8 +51,7 @@ enum ImNodesStyleVar_
 {
     ImNodesStyleVar_GridSpacing = 0,
     ImNodesStyleVar_NodeCornerRounding,
-    ImNodesStyleVar_NodePaddingHorizontal,
-    ImNodesStyleVar_NodePaddingVertical,
+    ImNodesStyleVar_NodePadding,
     ImNodesStyleVar_NodeBorderThickness,
     ImNodesStyleVar_LinkThickness,
     ImNodesStyleVar_LinkLineSegmentsPerLength,
@@ -146,8 +145,7 @@ struct ImNodesStyle
     float GridSpacing;
 
     float NodeCornerRounding;
-    float NodePaddingHorizontal;
-    float NodePaddingVertical;
+    ImVec2 NodePadding;
     float NodeBorderThickness;
 
     float LinkThickness;

--- a/imnodes_internal.h
+++ b/imnodes_internal.h
@@ -58,9 +58,7 @@ enum ImNodesClickInteractionType_
     ImNodesClickInteractionType_LinkCreation,
     ImNodesClickInteractionType_Panning,
     ImNodesClickInteractionType_BoxSelection,
-    ImNodesClickInteractionType_MiniMapPanning,
-    ImNodesClickInteractionType_MiniMapZooming,
-    ImNodesClickInteractionType_MiniMapSnapping,
+    ImNodesClickInteractionType_CenterOnRequest,
     ImNodesClickInteractionType_ImGuiItem,
     ImNodesClickInteractionType_None
 };
@@ -252,15 +250,38 @@ struct ImNodesEditorContext
     // ui related fields
     ImVec2 Panning;
     ImVec2 AutoPanningDelta;
+    // Minimum and maximum extents of all content in grid space. Valid after final
+    // ImNodes::EndNode() call.
+    ImRect GridContentBounds;
+
+    // When ImNodesClickInteractionType_CenterOnRequest is set, indicates location in grid space to
+    // center on.
+    ImVec2 CenterOnRequest;
 
     ImVector<int> SelectedNodeIndices;
     ImVector<int> SelectedLinkIndices;
 
     ImClickInteractionState ClickInteraction;
 
+    // Mini-map state set by MiniMap()
+
+    bool                               MiniMapEnabled;
+    ImNodesMiniMapLocation             MiniMapLocation;
+    float                              MiniMapSizeFraction;
+    ImNodesMiniMapNodeHoveringCallback MiniMapNodeHoveringCallback;
+    void*                              MiniMapNodeHoveringCallbackUserData;
+
+    // Mini-map state set during EndNodeEditor() call
+
+    ImRect                             MiniMapRectScreenSpace;
+    ImRect                             MiniMapContentScreenSpace;
+    float                              MiniMapScaling;
+
     ImNodesEditorContext()
         : Nodes(), Pins(), Links(), Panning(0.f, 0.f), SelectedNodeIndices(), SelectedLinkIndices(),
-          ClickInteraction()
+          ClickInteraction(), MiniMapEnabled(false), MiniMapSizeFraction(0.0f),
+          MiniMapNodeHoveringCallback(NULL), MiniMapNodeHoveringCallbackUserData(NULL),
+          MiniMapScaling(0.0f)
     {
     }
 };
@@ -280,13 +301,6 @@ struct ImNodesContext
     // Canvas extents
     ImVec2 CanvasOriginScreenSpace;
     ImRect CanvasRectScreenSpace;
-
-    // MiniMap state
-    ImRect                             MiniMapRectScreenSpace;
-    ImVec2                             MiniMapRectSnappingOffset;
-    float                              MiniMapZoom;
-    ImNodesMiniMapNodeHoveringCallback MiniMapNodeHoveringCallback;
-    void*                              MiniMapNodeHoveringCallbackUserData;
 
     // Debug helpers
     ImNodesScope CurrentScope;

--- a/imnodes_internal.h
+++ b/imnodes_internal.h
@@ -229,11 +229,19 @@ struct ImNodesColElement
 struct ImNodesStyleVarElement
 {
     ImNodesStyleVar Item;
-    float           Value;
+    float           FloatValue[2];
 
-    ImNodesStyleVarElement(const float value, const ImNodesStyleVar variable)
-        : Item(variable), Value(value)
+    ImNodesStyleVarElement(const ImNodesStyleVar variable, const float value)
+        : Item(variable)
     {
+        FloatValue[0] = value;
+    }
+
+    ImNodesStyleVarElement(const ImNodesStyleVar variable, const ImVec2 value)
+        : Item(variable)
+    {
+        FloatValue[0] = value.x;
+        FloatValue[1] = value.y;
     }
 };
 

--- a/imnodes_internal.h
+++ b/imnodes_internal.h
@@ -230,14 +230,12 @@ struct ImNodesStyleVarElement
     ImNodesStyleVar Item;
     float           FloatValue[2];
 
-    ImNodesStyleVarElement(const ImNodesStyleVar variable, const float value)
-        : Item(variable)
+    ImNodesStyleVarElement(const ImNodesStyleVar variable, const float value) : Item(variable)
     {
         FloatValue[0] = value;
     }
 
-    ImNodesStyleVarElement(const ImNodesStyleVar variable, const ImVec2 value)
-        : Item(variable)
+    ImNodesStyleVarElement(const ImNodesStyleVar variable, const ImVec2 value) : Item(variable)
     {
         FloatValue[0] = value.x;
         FloatValue[1] = value.y;
@@ -276,9 +274,9 @@ struct ImNodesEditorContext
 
     // Mini-map state set during EndNodeEditor() call
 
-    ImRect                             MiniMapRectScreenSpace;
-    ImRect                             MiniMapContentScreenSpace;
-    float                              MiniMapScaling;
+    ImRect MiniMapRectScreenSpace;
+    ImRect MiniMapContentScreenSpace;
+    float  MiniMapScaling;
 
     ImNodesEditorContext()
         : Nodes(), Pins(), Links(), Panning(0.f, 0.f), SelectedNodeIndices(), SelectedLinkIndices(),

--- a/imnodes_internal.h
+++ b/imnodes_internal.h
@@ -58,7 +58,6 @@ enum ImNodesClickInteractionType_
     ImNodesClickInteractionType_LinkCreation,
     ImNodesClickInteractionType_Panning,
     ImNodesClickInteractionType_BoxSelection,
-    ImNodesClickInteractionType_CenterOnRequest,
     ImNodesClickInteractionType_ImGuiItem,
     ImNodesClickInteractionType_None
 };
@@ -261,10 +260,6 @@ struct ImNodesEditorContext
     // Minimum and maximum extents of all content in grid space. Valid after final
     // ImNodes::EndNode() call.
     ImRect GridContentBounds;
-
-    // When ImNodesClickInteractionType_CenterOnRequest is set, indicates location in grid space to
-    // center on.
-    ImVec2 CenterOnRequest;
 
     ImVector<int> SelectedNodeIndices;
     ImVector<int> SelectedLinkIndices;


### PR DESCRIPTION
Minimally invasive change to allow pybind11 callback and callback data

Here is what it basically looks like in my project if anyone is curious.  I had to extend py::object to be assignable from NULL and also extend the bool conversion operator to test for Py_None.  I slapped it together over the weekend so I'm sure it can be improved.  The upside is not having to make any modifications to ImNodes source except for adding the conditional typedefs/macros.

CMakeLists.txt:
`target_compile_definitions(${THIS} PRIVATE IMNODES_USER_CONFIG=<imnodes_config.h>)`

imnodes_config.h:
```
#pragma once

#include <pybind11/functional.h>

namespace pybind11 {

inline bool PyWrapper_Check(PyObject *o) { return true; }

class wrapper : public object {
public:
    PYBIND11_OBJECT_DEFAULT(wrapper, object, PyWrapper_Check)
    wrapper(void* x) { m_ptr = (PyObject*)x; }
    explicit operator bool() const { return m_ptr != nullptr && m_ptr != Py_None; }
};

} //namespace pybind11

namespace py = pybind11;

#define ImNodesMiniMapNodeHoveringCallback py::wrapper

#define ImNodesMiniMapNodeHoveringCallbackUserData py::wrapper

```